### PR TITLE
sign in with google

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
+        "@abacritt/angularx-social-login": "^1.3.2",
         "@angular/animations": "^15.1.0",
         "@angular/cdk": "^15.1.2",
         "@angular/common": "^15.1.0",
@@ -35,6 +36,18 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
         "typescript": "~4.9.4"
+      }
+    },
+    "node_modules/@abacritt/angularx-social-login": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@abacritt/angularx-social-login/-/angularx-social-login-1.3.2.tgz",
+      "integrity": "sha512-xTF87u3lbb/d+bVj5PnveDG21YPalRfHN/eGQshl6qx1e0VqoSvDhlh4ugqie7g03P79xZij12Qxabzcz2f/mQ==",
+      "dependencies": {
+        "tslib": ">=2.5.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=15.0.0",
+        "@angular/core": ">=15.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11991,6 +12004,14 @@
     }
   },
   "dependencies": {
+    "@abacritt/angularx-social-login": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@abacritt/angularx-social-login/-/angularx-social-login-1.3.2.tgz",
+      "integrity": "sha512-xTF87u3lbb/d+bVj5PnveDG21YPalRfHN/eGQshl6qx1e0VqoSvDhlh4ugqie7g03P79xZij12Qxabzcz2f/mQ==",
+      "requires": {
+        "tslib": ">=2.5.0"
+      }
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/lvoytek/wedding-site#readme",
   "private": true,
   "dependencies": {
+    "@abacritt/angularx-social-login": "^1.3.2",
     "@angular/animations": "^15.1.0",
     "@angular/cdk": "^15.1.2",
     "@angular/common": "^15.1.0",

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -3,10 +3,12 @@
         <button mat-icon-button [routerLink]="''" aria-label="Home">
             <mat-icon>home</mat-icon>
         </button>
-        <div class="page-buttons">
+
+        <div class="buttons">
             <button mat-button [routerLink]="'/rsvp'">RSVP</button>
             <button mat-button [routerLink]="'/info'">Info</button>
 			<button mat-button [routerLink]="'/admin'">Admin</button>
+			<asl-google-signin-button type='icon' color="filled_black" shape="circle"></asl-google-signin-button>
         </div>
     </div>
 

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -8,10 +8,16 @@
     color: rgba($ll-black, 0.75);
 }
 
-.page-buttons * {
+.buttons {
+	display: inline-flex;
+	align-items: self-end;
+}
+
+.buttons * {
 	font-size: x-large;
 	font-weight: 900;
 }
+
 @media (min-width: 576px){
 	.page-buttons * {
 		font-size: large;

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,4 +1,3 @@
-import { SocialAuthService, SocialUser } from '@abacritt/angularx-social-login';
 import { Component, OnInit } from '@angular/core';
 
 @Component({
@@ -9,17 +8,9 @@ import { Component, OnInit } from '@angular/core';
 export class AppComponent implements OnInit{
 	title = 'Wedding Site';
 
-	user!: SocialUser;
-  	loggedIn!: boolean;
-
-	constructor(private authService: SocialAuthService) { }
+	constructor() { }
 
 	ngOnInit() {
-		this.authService.authState.subscribe((user) => {
-			this.user = user;
-			this.loggedIn = (user != null);
 
-			console.log(this.user);
-		});
 	}
 }

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,10 +1,25 @@
-import { Component } from '@angular/core';
+import { SocialAuthService, SocialUser } from '@abacritt/angularx-social-login';
+import { Component, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {
-  title = 'client';
+export class AppComponent implements OnInit{
+	title = 'Wedding Site';
+
+	user!: SocialUser;
+  	loggedIn!: boolean;
+
+	constructor(private authService: SocialAuthService) { }
+
+	ngOnInit() {
+		this.authService.authState.subscribe((user) => {
+			this.user = user;
+			this.loggedIn = (user != null);
+
+			console.log(this.user);
+		});
+	}
 }

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,16 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent implements OnInit{
+export class AppComponent {
 	title = 'Wedding Site';
-
-	constructor() { }
-
-	ngOnInit() {
-
-	}
 }

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { MaterialModule } from './material.module';
 import { RsvpComponent } from './components/rsvp/rsvp.component';
 import { InfoComponent } from './components/info/info.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { RsvpService } from './services/rsvp.service';
 import { GuestService } from './services/guest.service';
 import { ApiService } from './services/api.service';
@@ -17,6 +17,8 @@ import { RsvpFormComponent } from './components/forms/rsvp/rsvp.component';
 import { AdminComponent } from './components/admin/admin.component';
 import { AddGuestComponent } from './components/forms/add-guest/add-guest.component';
 import { SocialLoginModule, SocialAuthServiceConfig, GoogleLoginProvider } from '@abacritt/angularx-social-login';
+import { AuthService } from './services/auth.service';
+import { AuthInterceptor } from './services/authInterceptor.service';
 
 @NgModule({
   declarations: [
@@ -42,6 +44,7 @@ import { SocialLoginModule, SocialAuthServiceConfig, GoogleLoginProvider } from 
 	RsvpService,
 	GuestService,
 	ApiService,
+	AuthService,
 	{
 		provide: 'SocialAuthServiceConfig',
 		useValue: {
@@ -58,6 +61,11 @@ import { SocialLoginModule, SocialAuthServiceConfig, GoogleLoginProvider } from 
 			console.error(err);
 		  }
 		} as SocialAuthServiceConfig,
+	  },
+	  {
+		provide: HTTP_INTERCEPTORS,
+		useClass: AuthInterceptor,
+		multi: true
 	  }
   ],
   bootstrap: [AppComponent]

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { ApiService } from './services/api.service';
 import { RsvpFormComponent } from './components/forms/rsvp/rsvp.component';
 import { AdminComponent } from './components/admin/admin.component';
 import { AddGuestComponent } from './components/forms/add-guest/add-guest.component';
+import { SocialLoginModule, SocialAuthServiceConfig, GoogleLoginProvider } from '@abacritt/angularx-social-login';
 
 @NgModule({
   declarations: [
@@ -34,12 +35,30 @@ import { AddGuestComponent } from './components/forms/add-guest/add-guest.compon
     BrowserAnimationsModule,
 	FormsModule,
 	ReactiveFormsModule,
-    MaterialModule
+    MaterialModule,
+	SocialLoginModule
   ],
   providers: [
 	RsvpService,
 	GuestService,
-	ApiService
+	ApiService,
+	{
+		provide: 'SocialAuthServiceConfig',
+		useValue: {
+		  autoLogin: false,
+		  providers: [
+			{
+			  id: GoogleLoginProvider.PROVIDER_ID,
+			  provider: new GoogleLoginProvider(
+				"688686179589-2e4vehv846dbemjq5aqts284r3bfhhfu.apps.googleusercontent.com"
+			  )
+			},
+		  ],
+		  onError: (err) => {
+			console.error(err);
+		  }
+		} as SocialAuthServiceConfig,
+	  }
   ],
   bootstrap: [AppComponent]
 })

--- a/client/src/app/services/auth.service.ts
+++ b/client/src/app/services/auth.service.ts
@@ -1,0 +1,22 @@
+import { SocialAuthService, SocialUser } from '@abacritt/angularx-social-login';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+	providedIn: 'root'
+})
+export class AuthService {
+	//We don't really use these for anything so far, but that's okay
+	user!: SocialUser;
+
+	//Subscribe to changes in auth state
+	constructor(private googleService: SocialAuthService) {
+		this.googleService.authState.subscribe((user) => {
+			this.user = user;
+		});
+	}
+
+	get token(): string {
+		//Since we're subscribed to changes in auth state, that should mean our idToken is always refreshed
+		return this.user?.idToken || '';
+	}
+}

--- a/client/src/app/services/authInterceptor.service.ts
+++ b/client/src/app/services/authInterceptor.service.ts
@@ -1,0 +1,45 @@
+import {
+    HttpEvent,
+    HttpHandler,
+    HttpInterceptor,
+    HttpRequest,
+    HttpHeaders,
+} from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, from } from 'rxjs';
+import { AuthService } from './auth.service';
+@Injectable({
+	providedIn: 'root'
+})
+export class AuthInterceptor implements HttpInterceptor {
+    constructor(public authService: AuthService) {}
+
+    intercept(
+        request: HttpRequest<any>,
+        next: HttpHandler
+    ): Observable<HttpEvent<any>> {
+        return from(this.handleAccess(request, next));
+    }
+
+    private async handleAccess(
+        request: HttpRequest<any>,
+        next: HttpHandler
+    ): Promise<HttpEvent<any>> {
+        const token = this.authService.token;
+
+        let changedRequest = request;
+        const headerSettings: { [name: string]: string | string[] } = {};
+
+        if (token) {
+            headerSettings['Authorization'] = 'Bearer ' + token;
+        }
+
+        const newHeader = new HttpHeaders(headerSettings);
+
+        changedRequest = request.clone({
+            headers: newHeader,
+        });
+
+        return next.handle(changedRequest).toPromise() as Promise<HttpEvent<any>>;
+    }
+}


### PR DESCRIPTION
Allows SSO via google, and added an interceptor that adds idtoken jwt as bearer auth header. 

Needs styling and server side verification in the future. 

As well, I'd like to get the client id for the google login provider into an environment variable type thing. It's not really an issue for right now. Weirdly google does just want you to just...put it there plainly. But it'll make prod vs. dev better. 

Closes #21 