### PR TITLE
Add associate administration

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -25,6 +25,7 @@ import {
 } from '@abacritt/angularx-social-login';
 import { AuthService } from './services/auth.service';
 import { AuthInterceptor } from './services/authInterceptor.service';
+import { AddAssociateComponent } from './components/forms/add-associate/add-associate.component';
 
 @NgModule({
 	declarations: [
@@ -37,6 +38,7 @@ import { AuthInterceptor } from './services/authInterceptor.service';
 		AdminTableComponent,
 		CodeInputFormComponent,
 		AddGuestComponent,
+  AddAssociateComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/client/src/app/components/admin/admin.component.html
+++ b/client/src/app/components/admin/admin.component.html
@@ -5,3 +5,5 @@
 ></app-admin-table>
 
 <app-add-guest (createGuest)="createGuest($event)"></app-add-guest>
+
+<app-add-associate (associateGuests)="associateGuests($event)"></app-add-associate>

--- a/client/src/app/components/admin/admin.component.ts
+++ b/client/src/app/components/admin/admin.component.ts
@@ -48,6 +48,19 @@ export class AdminComponent implements OnInit {
 	}
 
 	/**
+	 * Associate two guests and all of their associates
+	 * @param uuids The uuids of the guests to associate
+	 */
+	associateGuests(uuids: { uuid1: string; uuid2: string }) {
+		this.api.associateGuests(uuids.uuid1, uuids.uuid2).subscribe(() => {
+			console.log('Guests associated');
+			this.api.getAllGuests().subscribe((data: any) => {
+				this.guestEntries = data;
+			});
+		});
+	}
+
+	/**
 	 * Update or add any info to an existing guest
 	 * @param guest All updated data to add
 	 */

--- a/client/src/app/components/forms/add-associate/add-associate.component.html
+++ b/client/src/app/components/forms/add-associate/add-associate.component.html
@@ -1,13 +1,13 @@
 <form class="rsvp-form" [formGroup]="guestForm" (ngSubmit)="onSubmit()">
-	<h2>Add a new guest:</h2>
+	<h2>Associate two groups of guests:</h2>
 	<mat-form-field>
-		<mat-label>First name</mat-label>
-		<input matInput type="text" formControlName="firstName">
+		<mat-label>UUID 1</mat-label>
+		<input matInput type="text" formControlName="uuid1">
 	</mat-form-field>
 
 	<mat-form-field>
-		<mat-label>Last name</mat-label>
-		<input matInput type="text" formControlName="lastName">
+		<mat-label>UUID 2</mat-label>
+		<input matInput type="text" formControlName="uuid2">
 	</mat-form-field>
 	<button class="submit-button" mat-flat-button color="accent" [disabled]="!guestForm.valid">Submit</button>
 </form>

--- a/client/src/app/components/forms/add-associate/add-associate.component.spec.ts
+++ b/client/src/app/components/forms/add-associate/add-associate.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddAssociateComponent } from './add-associate.component';
+
+describe('AddAssociateComponent', () => {
+  let component: AddAssociateComponent;
+  let fixture: ComponentFixture<AddAssociateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AddAssociateComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AddAssociateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/components/forms/add-associate/add-associate.component.ts
+++ b/client/src/app/components/forms/add-associate/add-associate.component.ts
@@ -1,0 +1,31 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { NonNullableFormBuilder, Validators } from '@angular/forms';
+
+@Component({
+	selector: 'app-add-associate',
+	templateUrl: './add-associate.component.html',
+	styleUrls: ['../form.component.scss'],
+})
+export class AddAssociateComponent {
+	@Output() associateGuests = new EventEmitter<{
+		uuid1: string;
+		uuid2: string;
+	}>();
+
+	guestForm = this.fb.group({
+		uuid1: ['', Validators.required],
+		uuid2: ['', Validators.required],
+	});
+
+	constructor(private fb: NonNullableFormBuilder) {}
+
+	onSubmit() {
+		const uuids: { uuid1: string; uuid2: string } = {
+			uuid1: this.guestForm.value.uuid1 || '',
+			uuid2: this.guestForm.value.uuid2 || '',
+		};
+
+		this.associateGuests.emit(uuids);
+		this.guestForm.reset();
+	}
+}

--- a/client/src/app/components/forms/admin-table/admin-table.component.html
+++ b/client/src/app/components/forms/admin-table/admin-table.component.html
@@ -69,6 +69,17 @@
 		</td>
 	  </ng-container>
 
+	  <ng-container matColumnDef="associates">
+		<th mat-header-cell *matHeaderCellDef>Associates</th>
+		<td mat-cell *matCellDef="let element">
+		  <mat-list>
+			<mat-list-item *ngFor="let associate of element.associates">
+				{{associate.firstName}} {{associate.lastName}}
+			</mat-list-item>
+		  </mat-list>
+		</td>
+	  </ng-container>
+
 	  <ng-container matColumnDef="actions">
 		<th mat-header-cell *matHeaderCellDef></th>
 		<td mat-cell *matCellDef="let element; let i = index;">
@@ -85,3 +96,6 @@
 	<tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
 </div>
+<button class="submit-button" mat-flat-button color="accent" (click)="onExpand()">
+	{{expanded ? "Contract" : "Expand"}}
+</button>

--- a/client/src/app/components/forms/admin-table/admin-table.component.ts
+++ b/client/src/app/components/forms/admin-table/admin-table.component.ts
@@ -2,25 +2,30 @@ import { Component, Input, Output, OnInit, EventEmitter } from '@angular/core';
 import { guestData } from '@libs/person';
 import { RecursivePartial } from '@libs/utils';
 
+const baseColumns: string[] = [
+	'uuid',
+	'firstName',
+	'lastName',
+	'pokemon',
+	'isInBridalParty',
+	'isInGroomishParty',
+	'isFamily',
+	'table',
+	'isGoing',
+	'actions',
+];
+
+const additionalColumns: string[] = ['email', 'associates'];
+
 @Component({
 	selector: 'app-admin-table',
 	templateUrl: './admin-table.component.html',
 	styleUrls: ['./admin-table.component.scss'],
 })
 export class AdminTableComponent implements OnInit {
-	displayedColumns: string[] = [
-		'uuid',
-		'firstName',
-		'lastName',
-		'pokemon',
-		'isInBridalParty',
-		'isInGroomishParty',
-		'isFamily',
-		'table',
-		'isGoing',
-		'email',
-		'actions',
-	];
+	displayedColumns: string[] = baseColumns;
+
+	expanded: boolean = false;
 
 	@Output() updateGuest = new EventEmitter<RecursivePartial<guestData>>();
 	@Output() deleteGuest = new EventEmitter<string>();
@@ -37,5 +42,16 @@ export class AdminTableComponent implements OnInit {
 
 	onSave(element: RecursivePartial<guestData>) {
 		this.updateGuest.emit(element);
+	}
+
+	onExpand() {
+		if (this.expanded) {
+			this.displayedColumns = baseColumns;
+			this.expanded = false;
+		} else {
+			this.displayedColumns = baseColumns.concat(additionalColumns);
+			console.log(this.displayedColumns);
+			this.expanded = true;
+		}
 	}
 }

--- a/client/src/app/components/forms/admin-table/admin-table.component.ts
+++ b/client/src/app/components/forms/admin-table/admin-table.component.ts
@@ -50,7 +50,6 @@ export class AdminTableComponent implements OnInit {
 			this.expanded = false;
 		} else {
 			this.displayedColumns = baseColumns.concat(additionalColumns);
-			console.log(this.displayedColumns);
 			this.expanded = true;
 		}
 	}

--- a/client/src/app/components/forms/admin-table/admin-table.component.ts
+++ b/client/src/app/components/forms/admin-table/admin-table.component.ts
@@ -45,12 +45,9 @@ export class AdminTableComponent implements OnInit {
 	}
 
 	onExpand() {
-		if (this.expanded) {
-			this.displayedColumns = baseColumns;
-			this.expanded = false;
-		} else {
-			this.displayedColumns = baseColumns.concat(additionalColumns);
-			this.expanded = true;
-		}
+		this.expanded = !this.expanded;
+		this.displayedColumns = this.expanded
+			? baseColumns.concat(additionalColumns)
+			: baseColumns;
 	}
 }

--- a/client/src/app/material.module.ts
+++ b/client/src/app/material.module.ts
@@ -10,6 +10,9 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatTableModule } from '@angular/material/table';
 import { MatGridListModule } from '@angular/material/grid-list';
+import {MatListModule} from '@angular/material/list';
+import {MatExpansionModule} from '@angular/material/expansion';
+
 @NgModule({
 	declarations: [],
 	imports: [
@@ -21,7 +24,10 @@ import { MatGridListModule } from '@angular/material/grid-list';
 		MatSelectModule,
 		MatInputModule,
 		MatCheckboxModule,
-		MatRadioModule
+		MatGridListModule,
+		MatRadioModule,
+		MatListModule,
+		MatExpansionModule
 	],
 	exports: [
 		MatButtonModule,
@@ -33,7 +39,9 @@ import { MatGridListModule } from '@angular/material/grid-list';
 		MatCheckboxModule,
 		MatTableModule,
 		MatGridListModule,
-		MatRadioModule
+		MatRadioModule,
+		MatListModule,
+		MatExpansionModule
 	],
 })
 export class MaterialModule {}

--- a/client/src/app/services/guest.service.ts
+++ b/client/src/app/services/guest.service.ts
@@ -11,6 +11,10 @@ export class GuestService {
 		return this.api.post(`guest`, guest);
 	}
 
+	associateGuests(uuid1: string, uuid2:string) {
+		return this.api.post(`guest/associate`, {uuid1, uuid2});
+	}
+
 	editGuest(guest: RecursivePartial<guestData>) {
 		return this.api.put(`guest/${guest.uuid}`, guest);
 	}

--- a/server/src/guest/guest.controller.ts
+++ b/server/src/guest/guest.controller.ts
@@ -85,26 +85,28 @@ export class GuestController {
 
 	/**
 	 * Associate a guest and all their associates with another guest and their associates
-	 * @param uuid1 The uuid of the first guest
-	 * @param uuid2 The uuid of the second guest
+	 * @param uuids The uuids of the guests to associate
 	 */
 	@UseGuards(JwtAdminAuthGuard)
-	@Put(':uuid1/associate/:uuid2')
+	@Post('associate')
 	async associateAll(
-		@Param('uuid1') uuid1: string,
-		@Param('uuid2') uuid2: string,
+		@Body() uuids: {uuid1: string, uuid2: string}
 	) {
+		console.log("Hi");
+		console.log(uuids);
 		const guest1PrimaryData: primaryData =
-			await this.guestService.getPrimaryData(uuid1);
+			await this.guestService.getPrimaryData(uuids.uuid1);
 		const guest2PrimaryData: primaryData =
-			await this.guestService.getPrimaryData(uuid1);
+			await this.guestService.getPrimaryData(uuids.uuid2);
+
+		console.log(guest1PrimaryData, guest2PrimaryData);
 
 		if (!guest1PrimaryData || !guest2PrimaryData) return null;
 
 		let guest1AndAssociates: primaryData[] =
-			await this.associateService.getAllAssociates(uuid1);
+			await this.associateService.getAllAssociates(uuids.uuid1);
 		let guest2AndAssociates: primaryData[] =
-			await this.associateService.getAllAssociates(uuid2);
+			await this.associateService.getAllAssociates(uuids.uuid2);
 
 		if (guest1AndAssociates) {
 			guest1AndAssociates.push(guest1PrimaryData);

--- a/server/src/guest/guest.controller.ts
+++ b/server/src/guest/guest.controller.ts
@@ -92,14 +92,10 @@ export class GuestController {
 	async associateAll(
 		@Body() uuids: {uuid1: string, uuid2: string}
 	) {
-		console.log("Hi");
-		console.log(uuids);
 		const guest1PrimaryData: primaryData =
 			await this.guestService.getPrimaryData(uuids.uuid1);
 		const guest2PrimaryData: primaryData =
 			await this.guestService.getPrimaryData(uuids.uuid2);
-
-		console.log(guest1PrimaryData, guest2PrimaryData);
 
 		if (!guest1PrimaryData || !guest2PrimaryData) return null;
 

--- a/server/src/guest/guest.controller.ts
+++ b/server/src/guest/guest.controller.ts
@@ -84,6 +84,48 @@ export class GuestController {
 	}
 
 	/**
+	 * Associate a guest and all their associates with another guest and their associates
+	 * @param uuid1 The uuid of the first guest
+	 * @param uuid2 The uuid of the second guest
+	 */
+	@UseGuards(JwtAdminAuthGuard)
+	@Put(':uuid1/associate/:uuid2')
+	async associateAll(
+		@Param('uuid1') uuid1: string,
+		@Param('uuid2') uuid2: string,
+	) {
+		const guest1PrimaryData: primaryData =
+			await this.guestService.getPrimaryData(uuid1);
+		const guest2PrimaryData: primaryData =
+			await this.guestService.getPrimaryData(uuid1);
+
+		if (!guest1PrimaryData || !guest2PrimaryData) return null;
+
+		let guest1AndAssociates: primaryData[] =
+			await this.associateService.getAllAssociates(uuid1);
+		let guest2AndAssociates: primaryData[] =
+			await this.associateService.getAllAssociates(uuid2);
+
+		if (guest1AndAssociates) {
+			guest1AndAssociates.push(guest1PrimaryData);
+		} else {
+			guest1AndAssociates = [guest1PrimaryData];
+		}
+
+		if (guest2AndAssociates) {
+			guest2AndAssociates.push(guest2PrimaryData);
+		} else {
+			guest2AndAssociates = [guest2PrimaryData];
+		}
+
+		for (const associate1 of guest1AndAssociates) {
+			for (const associate2 of guest2AndAssociates) {
+				this.associateService.create(associate1, associate2);
+			}
+		}
+	}
+
+	/**
 	 * Make a user an admin
 	 * @param uuid The uuid of the user
 	 */


### PR DESCRIPTION
Added an extend button to the admin table which shows additional info, including associates when extended. The associates section looks like:

![image](https://user-images.githubusercontent.com/35419443/234168416-e658de31-c584-455f-abaa-ab6f0f2f9bbb.png)

Also added an input section for associating two guests and all their associates using uuids:

![image](https://user-images.githubusercontent.com/35419443/234168581-895c42c0-310d-46e7-ab3c-276dff954b1e.png)

Yeah it looks kinda bad, but its good enough for admin stuff

Closes #54