### PR TITLE
Associate limit

### DIFF
--- a/client/src/app/components/forms/admin-table/admin-table.component.html
+++ b/client/src/app/components/forms/admin-table/admin-table.component.html
@@ -50,8 +50,15 @@
 
 	  <ng-container matColumnDef="table">
 		<th mat-header-cell *matHeaderCellDef>Table</th>
-		<<td mat-cell *matCellDef="let element">
+		<td mat-cell *matCellDef="let element">
 		  <input matInput [(ngModel)]="element.table" type="number" />
+		</td>
+	  </ng-container>
+
+	  <ng-container matColumnDef="associateLimit">
+		<th mat-header-cell *matHeaderCellDef>Guest Limit</th>
+		<td mat-cell *matCellDef="let element">
+		  <input matInput [(ngModel)]="element.associateLimit" type="number" />
 		</td>
 	  </ng-container>
 

--- a/client/src/app/components/forms/admin-table/admin-table.component.scss
+++ b/client/src/app/components/forms/admin-table/admin-table.component.scss
@@ -24,7 +24,8 @@ td.mat-column-uuid {
 	}
 }
 
-.mat-column-table {
+.mat-column-table,
+.mat-column-associateLimit {
 	input {
 		width: 35px;
 	}

--- a/client/src/app/components/forms/admin-table/admin-table.component.ts
+++ b/client/src/app/components/forms/admin-table/admin-table.component.ts
@@ -11,6 +11,7 @@ const baseColumns: string[] = [
 	'isInGroomishParty',
 	'isFamily',
 	'table',
+	'associateLimit',
 	'isGoing',
 	'actions',
 ];

--- a/client/src/app/components/forms/rsvp/rsvp.component.html
+++ b/client/src/app/components/forms/rsvp/rsvp.component.html
@@ -39,7 +39,7 @@
 	<div formArrayName="guests" *ngIf="attending">
 		<hr>
 		<div class="add-guest">
-			<button mat-fab color="accent" type="button" (click)="addGuest()">
+			<button mat-fab color="accent" type="button" [disabled]="associatesAtCapacity" (click)="addGuest()">
 			  <mat-icon>add</mat-icon>
 			</button>
 		</div>

--- a/client/src/app/components/forms/rsvp/rsvp.component.ts
+++ b/client/src/app/components/forms/rsvp/rsvp.component.ts
@@ -74,7 +74,7 @@ export class RsvpFormComponent implements OnChanges {
 				firstName: ['', Validators.required],
 				lastName: ['', Validators.required],
 				email: ['', [Validators.email]],
-				dietaryRestrictions: ['', Validators.required],
+				dietaryRestrictions: [''],
 			});
 
 			newGuest.get('firstName')?.value;

--- a/libs/types/person.d.ts
+++ b/libs/types/person.d.ts
@@ -26,6 +26,7 @@ type assignmentData = {
 	isInBridalParty: boolean;
 	isFamily: boolean;
 	pokemon: string;
+	associateLimit: number;
 };
 
 /**

--- a/server/src/assignment/assignment.service.ts
+++ b/server/src/assignment/assignment.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { Repository, UpdateResult } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Guest } from '@entities/guest.entity';
 import { Assignment } from '@entities/assignment.entity';
 
 import { assignmentData, primaryData } from '@libs/person';
@@ -48,6 +47,7 @@ export class AssignmentService {
 			isInBridalParty: assignmentUpdate.isInBridalParty,
 			isFamily: assignmentUpdate.isFamily,
 			pokemon: assignmentUpdate.pokemon,
+			associateLimit: assignmentUpdate.associateLimit,
 		};
 
 		if (!Object.values(assignmentUpdateData).every((el) => el == null))

--- a/server/src/entities/assignment.entity.ts
+++ b/server/src/entities/assignment.entity.ts
@@ -27,6 +27,9 @@ export class Assignment {
 	@Column({ unique: true })
 	pokemon: string;
 
+	@Column({default: 1})
+	associateLimit: number;
+
 	@OneToOne(() => Guest, { onDelete: 'CASCADE' })
 	@JoinColumn()
 	guest: Guest;

--- a/server/src/rsvp/rsvp.controller.ts
+++ b/server/src/rsvp/rsvp.controller.ts
@@ -271,6 +271,9 @@ export class RsvpController {
 
 		const guestRSVP = await this.rsvpService.get(guestToGet.uuid);
 		const guestContact = await this.contactService.get(guestToGet.uuid);
+		const associateLimit: number = (
+			await this.assignmentService.get(guestToGet.uuid)
+		)?.associateLimit;
 
 		// If guest has an associated google account, make sure they are logged in
 		if (
@@ -292,9 +295,15 @@ export class RsvpController {
 				if (newAssociate) associates.push(newAssociate);
 			}
 
-			return { ...guestToGet, ...guestRSVP, ...guestContact, associates };
+			return {
+				...guestToGet,
+				...guestRSVP,
+				...guestContact,
+				associates,
+				associateLimit,
+			};
 		}
 
-		return { ...guestToGet, ...guestRSVP, ...guestContact };
+		return { ...guestToGet, ...guestRSVP, ...guestContact, associateLimit };
 	}
 }

--- a/server/src/rsvp/rsvp.controller.ts
+++ b/server/src/rsvp/rsvp.controller.ts
@@ -69,10 +69,17 @@ export class RsvpController {
 				? await this.rsvpService.createOrUpdate(guest, rsvp)
 				: undefined;
 
-		// Add or update RSVP info for each associate provided
+		// Add or update RSVP info for each associate provided up to the associate limit
 		const associates: primaryData[] = [];
 		if (rsvp.associates) {
-			for (const associateInfo of rsvp.associates) {
+			const associateLimit =
+				(await this.assignmentService.get(guest.uuid))
+					?.associateLimit || null;
+
+			for (let i = 0; i < rsvp.associates.length; i++) {
+				if (associateLimit && i >= associateLimit) break;
+
+				const associateInfo = rsvp.associates[i];
 				let associate: primaryData = null;
 
 				// The associate already has a uuid, use the existing guest associated with it and update name if needed


### PR DESCRIPTION
Limit the number of associates a guest can add based on an assigned value. Disable button accordingly in RSVP. Closes #58

Also remove the dietary restriction requirement for associates for consistency