### PR TITLE
Mess with info page styling a bit

### DIFF
--- a/client/src/app/components/info/info.component.scss
+++ b/client/src/app/components/info/info.component.scss
@@ -1,10 +1,15 @@
 .venue-info {
-    padding-top: 1rem;
     display: flex;
     flex-direction: column;
     align-items: center;
+
+	h1 {
+		font-size: min(3em, 13vw);
+		font-family: 'DancingScript', 'Serif';;
+	}
 }
 
 .map {
+	min-width: 80%;
 	max-width: 90%;
 }


### PR DESCRIPTION
Closes #63 

Before:
![image](https://user-images.githubusercontent.com/44076677/235263368-16bd40e6-53cb-4011-a390-81c30eb8d920.png)

![image](https://user-images.githubusercontent.com/44076677/235263409-6c36412a-daf0-49bb-9a07-3dbfb2a95cb6.png)


After:

![image](https://user-images.githubusercontent.com/44076677/235263438-37130ecb-1ffe-4692-ab1f-8aba27d886e6.png)
![image](https://user-images.githubusercontent.com/44076677/235263466-4d30590f-ac34-48fc-af4f-95c269eec981.png)


Thoughts?

