### PR TITLE
Add faq

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { RsvpService } from './services/rsvp.service';
 import { GuestService } from './services/guest.service';
+import { InfoService } from './services/info.service';
 import { ApiService } from './services/api.service';
 import { RsvpFormComponent } from './components/forms/rsvp/rsvp.component';
 import { CodeInputFormComponent } from './components/forms/code-input-form/code-input-form.component';
@@ -54,6 +55,7 @@ import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 	providers: [
 		RsvpService,
 		GuestService,
+		InfoService,
 		ApiService,
 		AuthService,
 		{

--- a/client/src/app/components/info/info.component.html
+++ b/client/src/app/components/info/info.component.html
@@ -3,16 +3,6 @@
 <div class="info-content">
 	<div class="faqs">
 		<mat-accordion>
-			<div>
-				<mat-expansion-panel togglePosition="before">
-					<mat-expansion-panel-header class="faq-header">
-					<mat-panel-title class="faq-question">
-						Venue
-					</mat-panel-title>
-					</mat-expansion-panel-header>
-					<iframe class="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2926.1299888559643!2d-78.82618368505368!3d42.827867913423205!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89d30e2f0ed813f9%3A0x292c86b54ab3cb05!2sBuffalo%20and%20Erie%20County%20Botanical%20Gardens!5e0!3m2!1sen!2sus!4v1671925481036!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-				</mat-expansion-panel>
-			</div>
 			<div *ngFor="let faq of faqs; let i = index">
 				<mat-expansion-panel togglePosition="before">
 					<mat-expansion-panel-header class="faq-header">

--- a/client/src/app/components/info/info.component.html
+++ b/client/src/app/components/info/info.component.html
@@ -1,5 +1,19 @@
-<div class="venue-info">
-    <h1>Venue</h1>
-    <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2926.1299888559643!2d-78.82618368505368!3d42.827867913423205!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89d30e2f0ed813f9%3A0x292c86b54ab3cb05!2sBuffalo%20and%20Erie%20County%20Botanical%20Gardens!5e0!3m2!1sen!2sus!4v1671925481036!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+<div class="page-title">
+    <h1>Information</h1>
+</div>
+
+<div class="faqs">
+	<mat-accordion>
+		<div *ngFor="let faq of faqs; let i = index">
+			<mat-expansion-panel togglePosition="before">
+				<mat-expansion-panel-header class="faq-header">
+				  <mat-panel-title class="faq-question">
+					{{faq.question}}
+				  </mat-panel-title>
+				</mat-expansion-panel-header>
+				<div [innerHTML]="faq.answer"></div>
+			</mat-expansion-panel>
+		</div>
+	</mat-accordion>
 </div>
 

--- a/client/src/app/components/info/info.component.html
+++ b/client/src/app/components/info/info.component.html
@@ -4,6 +4,16 @@
 
 <div class="faqs">
 	<mat-accordion>
+		<div>
+			<mat-expansion-panel togglePosition="before">
+				<mat-expansion-panel-header class="faq-header">
+				  <mat-panel-title class="faq-question">
+					Venue
+				  </mat-panel-title>
+				</mat-expansion-panel-header>
+				<iframe class="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2926.1299888559643!2d-78.82618368505368!3d42.827867913423205!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89d30e2f0ed813f9%3A0x292c86b54ab3cb05!2sBuffalo%20and%20Erie%20County%20Botanical%20Gardens!5e0!3m2!1sen!2sus!4v1671925481036!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+			</mat-expansion-panel>
+		</div>
 		<div *ngFor="let faq of faqs; let i = index">
 			<mat-expansion-panel togglePosition="before">
 				<mat-expansion-panel-header class="faq-header">

--- a/client/src/app/components/info/info.component.html
+++ b/client/src/app/components/info/info.component.html
@@ -1,29 +1,29 @@
-<div class="page-title">
-    <h1>Information</h1>
-</div>
+<div class="page-title"><h1>Information</h1></div>
 
-<div class="faqs">
-	<mat-accordion>
-		<div>
-			<mat-expansion-panel togglePosition="before">
-				<mat-expansion-panel-header class="faq-header">
-				  <mat-panel-title class="faq-question">
-					Venue
-				  </mat-panel-title>
-				</mat-expansion-panel-header>
-				<iframe class="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2926.1299888559643!2d-78.82618368505368!3d42.827867913423205!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89d30e2f0ed813f9%3A0x292c86b54ab3cb05!2sBuffalo%20and%20Erie%20County%20Botanical%20Gardens!5e0!3m2!1sen!2sus!4v1671925481036!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-			</mat-expansion-panel>
-		</div>
-		<div *ngFor="let faq of faqs; let i = index">
-			<mat-expansion-panel togglePosition="before">
-				<mat-expansion-panel-header class="faq-header">
-				  <mat-panel-title class="faq-question">
-					{{faq.question}}
-				  </mat-panel-title>
-				</mat-expansion-panel-header>
-				<div [innerHTML]="faq.answer"></div>
-			</mat-expansion-panel>
-		</div>
-	</mat-accordion>
+<div class="info-content">
+	<div class="faqs">
+		<mat-accordion>
+			<div>
+				<mat-expansion-panel togglePosition="before">
+					<mat-expansion-panel-header class="faq-header">
+					<mat-panel-title class="faq-question">
+						Venue
+					</mat-panel-title>
+					</mat-expansion-panel-header>
+					<iframe class="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2926.1299888559643!2d-78.82618368505368!3d42.827867913423205!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89d30e2f0ed813f9%3A0x292c86b54ab3cb05!2sBuffalo%20and%20Erie%20County%20Botanical%20Gardens!5e0!3m2!1sen!2sus!4v1671925481036!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+				</mat-expansion-panel>
+			</div>
+			<div *ngFor="let faq of faqs; let i = index">
+				<mat-expansion-panel togglePosition="before">
+					<mat-expansion-panel-header class="faq-header">
+					<mat-panel-title class="faq-question">
+						{{faq.question}}
+					</mat-panel-title>
+					</mat-expansion-panel-header>
+					<div [innerHTML]="faq.answer"></div>
+				</mat-expansion-panel>
+			</div>
+		</mat-accordion>
+	</div>
 </div>
 

--- a/client/src/app/components/info/info.component.scss
+++ b/client/src/app/components/info/info.component.scss
@@ -11,7 +11,21 @@
 	}
 }
 
+.info-content {
+	display:flex;
+	flex-direction: column;
+}
+
+.faqs {
+	flex: 1;
+	padding: 2rem;
+
+	@media (min-width: 768px) {
+		width: 70%;
+    	align-self: center;
+	}
+}
+
 .map {
-	min-width: 80%;
-	max-width: 90%;
+	width: 100%;
 }

--- a/client/src/app/components/info/info.component.scss
+++ b/client/src/app/components/info/info.component.scss
@@ -1,4 +1,6 @@
-.venue-info {
+@import url('../../../assets/fonts.css');
+
+.page-title {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/client/src/app/components/info/info.component.ts
+++ b/client/src/app/components/info/info.component.ts
@@ -1,10 +1,23 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { InfoService } from '../../services/info.service';
+import { faqData } from '@libs/info';
 
 @Component({
-  selector: 'app-info',
-  templateUrl: './info.component.html',
-  styleUrls: ['./info.component.scss']
+	selector: 'app-info',
+	templateUrl: './info.component.html',
+	styleUrls: ['./info.component.scss'],
 })
-export class InfoComponent {
+export class InfoComponent implements OnInit {
+	faqs: faqData[] = [];
 
+	constructor(
+		private infoService: InfoService
+	) {}
+
+	ngOnInit() {
+		this.infoService.getAllFaqs().subscribe((data: any) => {
+			if(data)
+				this.faqs = data;
+		});
+	}
 }

--- a/client/src/app/services/info.service.ts
+++ b/client/src/app/services/info.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { faqData } from '@libs/info';
+import { ApiService } from './api.service';
+
+@Injectable()
+export class InfoService {
+	constructor(private api: ApiService) {}
+
+	getAllFaqs() {
+		return this.api.get(`faq/all`);
+	}
+}

--- a/libs/types/info.d.ts
+++ b/libs/types/info.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Frequently asked question data
+ */
+type faqData = {
+	question: string;
+	answer: string;
+};
+
+export { faqData };

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -13,6 +13,7 @@ import { Contact } from '@entities/contact.entity';
 import { Assignment } from '@entities/assignment.entity';
 import { Associate } from '@entities/associate.entity';
 import { Admin } from '@entities/admin.entity';
+import { Faq } from '@entities/faq.entity';
 
 import { RsvpController } from './rsvp/rsvp.controller';
 import { GuestService } from './guest/guest.service';
@@ -27,6 +28,8 @@ import { JwtStrategy } from '@auth/jwt.strategy';
 import { JwtAdminStrategy } from '@auth/jwtadmin.strategy';
 import { AuthService } from './auth/auth.service';
 import { AuthController } from './auth/auth.controller';
+import { FaqService } from './faq/faq.service';
+import { FaqController } from './faq/faq.controller';
 
 @Module({
 	imports: [
@@ -52,6 +55,7 @@ import { AuthController } from './auth/auth.controller';
 			Assignment,
 			Associate,
 			Admin,
+			Faq,
 		]),
 		JwtModule.registerAsync({
 			imports: [ConfigModule],
@@ -66,7 +70,13 @@ import { AuthController } from './auth/auth.controller';
 			inject: [ConfigService],
 		}),
 	],
-	controllers: [AppController, RsvpController, GuestController, AuthController],
+	controllers: [
+		AppController,
+		RsvpController,
+		GuestController,
+		AuthController,
+		FaqController,
+	],
 	providers: [
 		AppService,
 		GuestService,
@@ -77,7 +87,8 @@ import { AuthController } from './auth/auth.controller';
 		AdminService,
 		JwtStrategy,
 		JwtAdminStrategy,
-		AuthService
+		AuthService,
+		FaqService,
 	],
 })
 export class AppModule {}

--- a/server/src/entities/faq.entity.ts
+++ b/server/src/entities/faq.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Faq {
+	@PrimaryGeneratedColumn()
+	id: number;
+
+	@Column()
+	question: string;
+
+	@Column()
+	answer: string;
+}

--- a/server/src/faq/faq.controller.spec.ts
+++ b/server/src/faq/faq.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FaqController } from './faq.controller';
+
+describe('FaqController', () => {
+  let controller: FaqController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FaqController],
+    }).compile();
+
+    controller = module.get<FaqController>(FaqController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/faq/faq.controller.ts
+++ b/server/src/faq/faq.controller.ts
@@ -1,0 +1,51 @@
+import {
+	Controller,
+	Post,
+	Get,
+	Delete,
+	Param,
+	Body,
+	UseGuards,
+} from '@nestjs/common';
+import { DeleteResult } from 'typeorm';
+
+import { FaqService } from './faq.service';
+import { JwtAdminAuthGuard } from '@auth/jwtadmin.guard';
+
+import { faqData } from '@libs/info';
+
+@Controller('faq')
+export class FaqController {
+	constructor(private faqService: FaqService) {}
+
+	/**
+	 * Create a new FAQ
+	 * @param faq An FAQ in the body of the request
+	 * @returns The created FAQ
+	 */
+	@UseGuards(JwtAdminAuthGuard)
+	@Post('')
+	async create(@Body() faq: faqData): Promise<any> {
+		return await this.faqService.create(faq);
+	}
+
+	/**
+	 * Get all FAQs
+	 * @returns All FAQs as an array of faqData
+	 */
+	@Get('all')
+	async readAll(): Promise<faqData[]> {
+		return await this.faqService.getAll();
+	}
+
+	/**
+	 * Delete an FAQ
+	 * @param id The id number of the FAQ to remove
+	 * @returns The result of the deletion
+	 */
+	@UseGuards(JwtAdminAuthGuard)
+	@Delete(':id')
+	async remove(@Param('id') id: number): Promise<DeleteResult> {
+		return this.faqService.remove(id);
+	}
+}

--- a/server/src/faq/faq.service.spec.ts
+++ b/server/src/faq/faq.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FaqService } from './faq.service';
+
+describe('FaqService', () => {
+  let service: FaqService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FaqService],
+    }).compile();
+
+    service = module.get<FaqService>(FaqService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/faq/faq.service.ts
+++ b/server/src/faq/faq.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { Repository, DeleteResult } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Faq } from '@entities/faq.entity';
+
+import { faqData } from '@libs/info';
+
+@Injectable()
+export class FaqService {
+	constructor(
+		@InjectRepository(Faq)
+		private faqRepository: Repository<Faq>,
+	) {}
+
+	/**
+	 * Create a new question + answer FAQ entry
+	 * @param faq The question string and HTML answer
+	 * @returns The copy of the FAQ that was created
+	 */
+	async create(faq: faqData): Promise<faqData> {
+		return !faq ? null : await this.faqRepository.save(faq);
+	}
+
+	/**
+	 * Get all FAQs
+	 * @returns The stored FAQs in an array of faqData
+	 */
+	async getAll(): Promise<faqData[]> {
+		return this.faqRepository.find();
+	}
+
+	/**
+	 * Remove an FAQ from the table
+	 * @param id The id number of the FAQ to remove
+	 * @returns The result of the removal
+	 */
+	async remove(id: number): Promise<DeleteResult> {
+		return await this.faqRepository.delete({ id });
+	}
+}


### PR DESCRIPTION
Increase the utility of the info page by adding a dynamic information/FAQ section that we can add to as we go. The answer portion can contain HTML for links, emphasis, paragraphs, etc.

Here are some examples of what it looks like with some questions filled out:

Desktop:
![Screenshot from 2023-05-31 18-24-40](https://github.com/lvoytek/wedding-site/assets/35419443/8a7f4b54-a4fc-4e04-ad55-31c8534818e6)

![Screenshot from 2023-05-31 18-29-38](https://github.com/lvoytek/wedding-site/assets/35419443/2757c0b5-2523-42f9-b9e4-f11d880e83d7)

Mobile:
![image](https://github.com/lvoytek/wedding-site/assets/35419443/3b5230eb-f2f2-413e-9794-f43c83e9bb38)

Closes #66 
